### PR TITLE
Fixed incorrect code example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage
 
 .. code:: python
 
-   from pynames.generators import GENDER,  LANGUAGE
+   from pynames import GENDER, LANGUAGE
 
 All generators are divided by "races", so that all generators of elven names are placed in the module ``pynames.generators.elven``, etc.
 


### PR DESCRIPTION
Пример в описании просто не работал, исправил его.

```
>>> from pynames.generators import GENDER,  LANGUAGE
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name GENDER
>>> from pynames import GENDER, LANGUAGE
>>> GENDER
<class pynames.relations.GENDER at 0x101da2050>
```
